### PR TITLE
Run doc-tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,10 @@ jobs:
 
       - name: Test
         run: cargo test
+
+      - name: Doc Test
+        # Doc-Tests cannot be run on "cdylib" crates.
+        # Due to this the crate will be changed to a regular "lib" and then run the Doc-Tests.
+        run: |
+          sed -i 's/"cdylib"/"lib"/g' Cargo.toml
+          cargo test --doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo test
 
       - name: Doc Test
-        # Doc-Tests cannot be run on "cdylib" crates.
+        # MinerSebas: Doc-Tests cannot be run on "cdylib" crates.
         # Due to this the crate will be changed to a regular "lib" and then run the Doc-Tests.
         run: |
           sed -i 's/"cdylib"/"lib"/g' Cargo.toml


### PR DESCRIPTION
Doc-Tests cannot be run on "cdylib" crates.
Due to this the crate will be changed to a regular "lib" and then run the Doc-Tests.